### PR TITLE
Update io-package.json

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -204,12 +204,12 @@
                 "role":  "value.speed.wind",
                 "read":  true,
                 "write": false,
-                "unit":  "km/h",
-                "desc":  "Forecast for wind speed in km/h"
+                "unit":  "m/s",
+                "desc":  "Forecast for wind speed in m/s"
             },
             "native": {
                 "path": "wind.speed",
-                "metric": "km/h",
+                "metric": "m/s",
                 "imperial": "m/h",
                 "type": "current"
             }
@@ -569,12 +569,12 @@
                 "role":  "value.speed.wind.forecast.0",
                 "read":  true,
                 "write": false,
-                "unit":  "km/h",
-                "desc":  "Forecast for wind speed in km/h"
+                "unit":  "m/s",
+                "desc":  "Forecast for wind speed in m/s"
             },
             "native": {
                 "path": "wind.speed",
-                "metric": "km/h",
+                "metric": "m/s",
                 "imperial": "m/h",
                 "type": "forecast"
             }


### PR DESCRIPTION
Einheit für Windgeschwindigkeit korrigiert, API liefert bei "metric" m/s statt km/h

[https://openweathermap.org/current](https://openweathermap.org/current)