### PR TITLE
Added period datapoints

### DIFF
--- a/main.js
+++ b/main.js
@@ -217,6 +217,8 @@ function parseForecast(data) {
     let sum = [];
     let date = null;
     let day = 0;
+    
+	const isStart = !tasks.length;
     for (let period = 0; period < data.list.length; period++) {
         const values = extractValues(data.list[period], forecastIds);
         const curDate = new Date(values.date).getDate();
@@ -231,9 +233,17 @@ function parseForecast(data) {
         } else {
             sum.push(values);
         }
+        
+        for (const attr in values) {
+            if (!values.hasOwnProperty(attr)) continue;
+            tasks.push({id: 'forecast.period' + period + '.' + attr, val: values[attr], obj: forecastIds.find(obj => obj._id.split('.').pop() === attr), period});        
+        }
     }
     if (sum.length) {
         calculateAverage(sum, day);
+    }
+    if (isStart) {
+        processTasks();
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -234,10 +234,13 @@ function parseForecast(data) {
             sum.push(values);
         }
         
-        for (const attr in values) {
-            if (!values.hasOwnProperty(attr)) continue;
-            tasks.push({id: 'forecast.period' + period + '.' + attr, val: values[attr], obj: forecastIds.find(obj => obj._id.split('.').pop() === attr), period});        
-        }
+		Object.keys(values).forEach(attr => 
+            tasks.push({
+				id: 'forecast.period' + period + '.' + attr, 
+				val: values[attr], 
+				obj: forecastIds.find(obj => obj._id.split('.').pop() === attr), 
+				period
+			}));
     }
     if (sum.length) {
         calculateAverage(sum, day);


### PR DESCRIPTION
This patch adds the 40 period (3-hour-steps) of forecast data to the object tree in addition to the current daily aggregates. Fixes #22 