### PR TITLE
require node 16 due to adapter- core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/ioBroker/ioBroker.openweathermap"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "keywords": [
     "ioBroker",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail at node 14 and older. So this adapter reuires node 16 minimum